### PR TITLE
Fix an error where compilers cannot be set as output for another compiler

### DIFF
--- a/tombstone.sty
+++ b/tombstone.sty
@@ -48,7 +48,7 @@
     \newcommand{\compiler}[6][]{
         \matrix (##2) ##6 [%
             tmatrix,
-            anchor=##2-1-1.north west,
+            anchor=##2-1-1.south east,
             ##1
         ] {%
             {##3} \& $\to$ \& {##4} \\


### PR DESCRIPTION
Diagrams like the following were not possible before.
![scrot](https://cloud.githubusercontent.com/assets/1240168/23649885/67a32afa-0320-11e7-955c-e875498ace8b.png)
